### PR TITLE
fix(dev-env): bring back support for NPM for dev env

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "build": "gulp build",
     "build-dev": "gulp build:dev",
     "commitmsg": "validate-commit-msg",
-    "dev": "gulp serve & yarn serve",
+    "dev": "gulp serve & (if [[ -x yarn ]]; then yarn serve; else npm run serve; fi)",
     "lint": "eslint gulpfile.js server.js src tests demo",
     "prebuild": "gulp clean",
     "prepublish": "npm run build",


### PR DESCRIPTION
## Overview

This change brings back support for `npm run dev`.

## Testing / Reviewing

Testing should make sure `yarn` usage is not broken.