### PR TITLE
feat(l0): add in styles for l0 header

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
     "url": "https://github.com/carbon-design-system/carbon-addons-bluemix"
   },
   "bugs": {
-    "url": "https://github.com/carbon-design-system/carbon-addons-bluemix/issues"
+    "url":
+      "https://github.com/carbon-design-system/carbon-addons-bluemix/issues"
   },
-  "keywords": [
-    "eyeglass-module"
-  ],
+  "keywords": ["eyeglass-module"],
   "dependencies": {
     "lodash.debounce": "^4.0.8"
   },
@@ -31,7 +30,7 @@
     "babel-runtime": "^6.22.0",
     "bluebird": "~3.1.1",
     "browser-sync": "~2.10.0",
-    "carbon-components": "^7.26.5",
+    "carbon-components": "^8.0.0",
     "chai": "^3.5.0",
     "core-js": "^2.4.0",
     "custom-event": "^1.0.0",
@@ -97,7 +96,7 @@
     "vinyl-named": "^1.1.0"
   },
   "peerDependencies": {
-    "carbon-components": "^7.26.5"
+    "carbon-components": "^8.0.0"
   },
   "files": [
     "css/**/*",
@@ -121,13 +120,11 @@
     "test": "gulp test",
     "test:unit": "gulp test:unit",
     "test:a11y": "gulp test:a11y",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release":
+      "semantic-release pre && npm publish && semantic-release post"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --trailing-comma es5 --single-quote --write",
-      "git add"
-    ]
+    "*.js": ["prettier --trailing-comma es5 --single-quote --write", "git add"]
   },
   "config": {
     "commitizen": {

--- a/src/components/cloud-header/_cloud-header.scss
+++ b/src/components/cloud-header/_cloud-header.scss
@@ -1,64 +1,118 @@
 @import 'carbon-components/scss/globals/scss/colors';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 
+$cloud-header-link-color: $inverse-01 !default;
+$cloud-header-icon-color: $inverse-01 !default;
+$cloud-header-menu-color: $brand-02 !default;
+$cloud-header-background-color: $color__blue-90 !default;
+
+// $cloud-header-link-color: #152935;
+// $cloud-header-icon-color: #152935;
+// $cloud-header-menu-color: #734098;
+// $cloud-header-background-color: #fff;
+
 .cloud-header {
   display: flex;
   align-items: center;
-  background-color: $color__blue-90;
-  color: $inverse-01;
+  justify-content: space-between;
+  background-color: $cloud-header-background-color;
+  color: $cloud-header-link-color;
   height: rem(48px);
+  width: 100%;
 
   a {
-    color: $inverse-01;
+    color: $cloud-header-link-color;
     text-decoration: none;
   }
 }
 
-.cloud-header__app {
+.cloud-header__app,
+.cloud-header__global {
+  height: 100%;
   display: flex;
+  align-items: center;
 }
 
 .cloud-header__app-menu {
-  padding: 0 rem(12px);
-}
+  @include button-reset;
+  box-sizing: content-box;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 rem(24px);
+  height: 100%;
+  width: rem(16px);
 
-.cloud-header__app-menu ~ .cloud-header-brand {
-  margin-left: rem(-12px);
+  svg {
+    fill: $cloud-header-menu-color;
+    width: rem(16px);
+    height: rem(16px);
+  }
 }
 
 .cloud-header-brand {
+  height: 100%;
   display: flex;
   align-items: center;
-  padding-left: rem(12px);
 }
 
 .cloud-header-brand__icon {
-  padding-right: rem(10px);
+  height: rem(32px);
+  width: rem(32px);
+  margin-right: rem(10px);
 }
 
-.cloud-header__global {
-  display: flex;
-  margin-left: auto;
+.cloud-header-brand__text {
+  font-weight: 400;
+
+  span {
+    font-weight: 600;
+  }
 }
 
 .cloud-header-list {
+  margin-left: rem(16px);
+  height: 100%;
   display: flex;
+  align-items: center;
   list-style: none;
   padding: 0;
 }
 
 .cloud-header-list__item {
+  height: 100%;
   padding: 0 rem(16px);
+  display: flex;
+  align-items: center;
+}
 
-  .cloud-header-list--global & {
-    padding: 0 rem(12px);
+.cloud-header-list__link {
+  @include typescale('zeta');
+  height: 100%;
+  display: flex;
+  align-items: center;
+  font-weight: 400;
+  color: $cloud-header-link-color;
+}
 
-    &:last-child {
-      padding-right: rem(24px);
-    }
+.cloud-header-list--global {
+  margin-left: 0;
+
+  .cloud-header-list__item {
+    padding: 0;
   }
 }
 
-.bx--type-bold {
-  font-weight: 700;
+.cloud-header-list__btn {
+  @include button-reset;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 rem(16px);
+
+  svg {
+    fill: $cloud-header-icon-color;
+    height: rem(16px);
+    width: rem(16px);
+  }
 }

--- a/src/components/cloud-header/cloud-header.html
+++ b/src/components/cloud-header/cloud-header.html
@@ -1,22 +1,76 @@
 <nav class="cloud-header">
   <div class="cloud-header__app">
-    <div class="cloud-header__app-menu"></div>
+    <button type="button" class="cloud-header__app-menu">
+      <svg fill-rule='evenodd'>
+        <path d='M0 0h20v2H0zm0 6h20v2H0zm0 6h20v2H0z'></path>
+      </svg>
+    </button>
     <a class="cloud-header-brand" href="#">
-      <div class="cloud-header-brand__icon">icon</div>
-      <div class="cloud-header-brand__text">IBM <span class="bx--type-bold">Product Name</span></div>
+      <!-- <div class="cloud-header-brand__icon">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm0 4.6c2.8 0 5 2.2 5 5s-2.2 5-5 5-5-2.2-5-5 2.2-5 5-5zm7 14.5c-1.8 1.8-4.3 2.9-7 2.9s-5.2-1.1-7-2.9v-1.6c0-1.3.7-2 2-2h10c1.3 0 2 .7 2 2v1.6z"
+          />
+        </svg>
+      </div> -->
+      <h4 class="cloud-header-brand__text">IBM
+        <span>Product Name</span>
+      </h4>
     </a>
     <ul class="cloud-header-list">
-      <li class="cloud-header-list__item"><a href="#">Menu Item</a></li>
-      <li class="cloud-header-list__item"><a href="#">Menu Item</a></li>
-      <li class="cloud-header-list__item"><a href="#">Menu Item</a></li>
+      <li class="cloud-header-list__item">
+        <a class="cloud-header-list__link" href="#">Link 1</a>
+      </li>
+      <li class="cloud-header-list__item">
+        <a class="cloud-header-list__link" href="#">Link 2</a>
+      </li>
+      <li class="cloud-header-list__item">
+        <a class="cloud-header-list__link" href="#">Link 3</a>
+      </li>
     </ul>
   </div>
   <div class="cloud-header__global">
     <ul class="cloud-header-list cloud-header-list--global">
-      <li class="cloud-header-list__item"><a href="#">icon</a></li>
-      <li class="cloud-header-list__item"><a href="#">icon</a></li>
-      <li class="cloud-header-list__item"><a href="#">icon</a></li>
-      <li class="cloud-header-list__item"><a href="#">icon</a></li>
+      <li class="cloud-header-list__item">
+        <button class="cloud-header-list__btn" type="button">
+          <svg viewBox="0 0 25 25" fill-rule='evenodd'>
+            <title>search</title>
+            <path d='M16.036 18.455l2.404-2.405 5.586 5.587-2.404 2.404zM8.5 2C12.1 2 15 4.9 15 8.5S12.1 15 8.5 15 2 12.1 2 8.5 4.9 2 8.5 2zm0-2C3.8 0 0 3.8 0 8.5S3.8 17 8.5 17 17 13.2 17 8.5 13.2 0 8.5 0zM15 16a1 1 0 1 1 2 0 1 1 0 1 1-2 0'></path>
+          </svg>
+        </button>
+      </li>
+      <li class="cloud-header-list__item">
+        <button class="cloud-header-list__btn" type="button">
+          <svg width="16" height="16">
+            <title>notifications</title>
+            <path d="M9 1.11V0H7v1.11A5.022 5.022 0 0 0 3.1 4.9L1 14h5a2 2 0 0 0 4 0h5l-2.1-9.1A5.022 5.022 0 0 0 9 1.11z" />
+          </svg>
+        </button>
+      </li>
+      <li class="cloud-header-list__item">
+        <button class="cloud-header-list__btn" type="button">
+          <title>applications</title>
+          <svg width="16" height="16">
+            <circle cx="2" cy="2" r="2" />
+            <circle cx="8" cy="2" r="2" />
+            <circle cx="14" cy="2" r="2" />
+            <circle cx="2" cy="8" r="2" />
+            <circle cx="8" cy="8" r="2" />
+            <circle cx="14" cy="8" r="2" />
+            <circle cx="2" cy="14" r="2" />
+            <circle cx="8" cy="14" r="2" />
+            <circle cx="14" cy="14" r="2" />
+          </svg>
+        </button>
+      </li>
+      <li class="cloud-header-list__item">
+        <button class="cloud-header-list__btn" type="button">
+          <svg viewBox="0 0 24 24">
+            <title>user</title>
+            <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm0 4.6c2.8 0 5 2.2 5 5s-2.2 5-5 5-5-2.2-5-5 2.2-5 5-5zm7 14.5c-1.8 1.8-4.3 2.9-7 2.9s-5.2-1.1-7-2.9v-1.6c0-1.3.7-2 2-2h10c1.3 0 2 .7 2 2v1.6z"
+            />
+          </svg>
+        </button>
+      </li>
     </ul>
   </div>
 </nav>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,12 +1107,6 @@ buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
-bufferstreams@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/bufferstreams/-/bufferstreams-1.1.1.tgz#0161373060ac5988eff99058731114f6e195d51e"
-  dependencies:
-    readable-stream "^2.0.2"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1179,13 +1173,14 @@ caniuse-lite@^1.0.30000744:
   version "1.0.30000749"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000749.tgz#2ff382865aead8cca35dacfbab04f58effa4c01c"
 
-carbon-components@^7.0.0:
-  version "7.26.2"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-7.26.2.tgz#cc15b2717b9ba70be31000546f9819a6dc034eb9"
+carbon-components@^8.0.0:
+  version "8.1.12"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.1.12.tgz#8c254e5739896e3130ee3cbcec26ae13f507f2ab"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"
     lodash.debounce "^4.0.8"
+    warning "^3.0.0"
 
 carbon-icons@^6.0.4:
   version "6.2.0"
@@ -3175,14 +3170,6 @@ gulp-babel@^6.1.2:
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-eslint@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-eslint/-/gulp-eslint-3.0.1.tgz#04e57e3e18c6974267c12cf6855dc717d4a313bd"
-  dependencies:
-    bufferstreams "^1.1.1"
-    eslint "^3.0.0"
-    gulp-util "^3.0.6"
-
 gulp-jsdoc3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/gulp-jsdoc3/-/gulp-jsdoc3-0.2.1.tgz#cf595b1a3ccfa04f127a909892a4af489250cbf6"
@@ -3240,7 +3227,7 @@ gulp-uglify@^2.1.2:
     uglify-save-license "^0.4.1"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@^3.0.7, gulp-util@~3.0.7:
+gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -7341,6 +7328,12 @@ walk@^2.3.9:
 walkdir@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 wd@^1.4.0:
   version "1.4.1"


### PR DESCRIPTION
## Updates to L0 Header

![screen shot 2017-12-04 at 12 04 29 pm](https://user-images.githubusercontent.com/11928039/33568225-593a6252-d8eb-11e7-84b7-f26a95f10364.png)

- Added in 4 variables for theming purposes

```scss
$cloud-header-link-color: $inverse-01 !default;
$cloud-header-icon-color: $inverse-01 !default;
$cloud-header-menu-color: $brand-02 !default;
$cloud-header-background-color: $color__blue-90 !default;
```

To test theming, there is currently a `light` theme commented out in the `_cloud-header.scss` file. Simply uncomment these and recompile to verify theming works.


#### To Do 
- [ ] Update to `bx--` namespace 