### PR TITLE
chore(dependency): bump up carbon-components version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-runtime": "^6.22.0",
     "bluebird": "~3.1.1",
     "browser-sync": "~2.10.0",
-    "carbon-components": "^7.26.5",
+    "carbon-components": "^8.0.0",
     "chai": "^3.5.0",
     "core-js": "^2.4.0",
     "custom-event": "^1.0.0",
@@ -95,7 +95,7 @@
     "vinyl-named": "^1.1.0"
   },
   "peerDependencies": {
-    "carbon-components": "^7.26.5"
+    "carbon-components": "^7.26.5 || ^8.0.0"
   },
   "files": [
     "css/**/*",


### PR DESCRIPTION
### Changed

Bumps up Carbon release for `peerDependencies` and `devDependencies`

## Testing / Reviewing

Testing should make sure no component is broken.